### PR TITLE
api.w3.org no longer requires an API key

### DIFF
--- a/agenda.html
+++ b/agenda.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" data-gid='34314' data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US" data-gid='34314'>
 <head>
   <meta charset="utf-8">
   <title>Agenda</title>
@@ -9,7 +9,6 @@
   <script>
 const config = {
   gid: document.documentElement.getAttribute("data-gid"),
-  key: document.documentElement.getAttribute("data-apiary-key"),
   search: "agenda",
   cache: "https://labs.w3.org/github-cache",
 };

--- a/agendas.html
+++ b/agendas.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US">
 <head>
   <meta charset="utf-8">
   <title>Agenda board</title>
@@ -26,10 +26,8 @@
     - <a href="?gtype=business">business</a>
   </p>
 <script type="module">
-    import { fetchGroups, setW3CKey } from './w3c.js';
+    import { fetchGroups } from './w3c.js';
     import jsonrender from './jsonrender.js';
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     fetchGroups().then(groups => {
       let gtypeElt = document.getElementById("gtype");

--- a/browse.html
+++ b/browse.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US">
 
 <head>
   <meta charset="utf-8">
@@ -31,7 +31,7 @@
 
   <hr />
   <script type="module">
-    import { fetchGroup, fetchGroups, setW3CKey } from './w3c.js';
+    import { fetchGroup, fetchGroups } from './w3c.js';
     import query from './jsonquery.js';
     import jsonrender from './jsonrender.js';
     import LazyPromise from './lazypromise.js';
@@ -178,8 +178,6 @@
       history.pushState(config, config.gid, "?gid=" + config.gid + ((config.query)? "&query="+config.query : ""));
       renderGID().catch(console.error);
     };
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     fetchGroups().then(groups => {
       let elts = document.querySelectorAll("*.groups");

--- a/chairboard.html
+++ b/chairboard.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US">
 
 <head>
   <meta charset="utf-8">
@@ -411,7 +411,7 @@
 <hr>
 <a href='https://github.com/w3c/gargantua/'>It's on GitHub</a>
   <script type="module">
-    import { fetchGroup, fetchGroups, setW3CKey } from './w3c.js';
+    import { fetchGroup, fetchGroups } from './w3c.js';
     import jsonrender, { subscribe } from './jsonrender.js';
 
     // telemetry for performance monitoring
@@ -451,8 +451,6 @@
         return event["start"].split('T')[0];
       },
     };
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     let gid = document.documentElement.getAttribute("data-gid");
 

--- a/chairboards.html
+++ b/chairboards.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US">
 
 <head>
   <meta charset="utf-8">
@@ -29,10 +29,8 @@
   </p>
 
 <script type="module">
-    import { fetchGroups, setW3CKey } from './w3c.js';
+    import { fetchGroups } from './w3c.js';
     import jsonrender from './jsonrender.js';
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     fetchGroups().then(groups => {
       let gtypeElt = document.getElementById("gtype");

--- a/fetch-utils.js
+++ b/fetch-utils.js
@@ -1,6 +1,6 @@
 import LazyPromise from './lazypromise.js';
 
-// export { fetchGroup, fetchGroups, fetchJSON, fetchW3C, setW3CKey };
+// export { fetchGroup, fetchGroups, fetchJSON, fetchW3C };
 
 // This helps retrieve asynchronously information from the W3C API
 // fetchJSON and fetchW3C provide caching mechanisms
@@ -11,11 +11,6 @@ import LazyPromise from './lazypromise.js';
 
 // used by getW3CData and groupInfo
 const W3C_APIURL = "https://api.w3.org/";
-
-let W3C_APIKEY;
-function setW3CKey(key) {
-  W3C_APIKEY = key.toString();
-}
 
 let JSON_CACHE = {};
 
@@ -128,9 +123,7 @@ function fetchW3C(queryPath, expanders) {
   const mapper = (set) => resolveLinks(set, expanders);
   const ENTRY = queryPath.toString();
   if (API_CACHE[ENTRY]) return API_CACHE[ENTRY];
-  if (!W3C_APIKEY) throw new ReferenceError("Missing W3C key. Use setKey")
   const apiURL = new URL(queryPath, W3C_APIURL);
-  apiURL.searchParams.set("apikey", W3C_APIKEY);
   apiURL.searchParams.set("embed", "1"); // grab everything
   return API_CACHE[ENTRY] = fetchJSON(apiURL).then(data => {
     if (data.error) return data;
@@ -157,4 +150,4 @@ function fetchW3C(queryPath, expanders) {
   });
 }
 
-export { fetchJSON, fetchW3C, fetchHTML, setW3CKey };
+export { fetchJSON, fetchW3C, fetchHTML };

--- a/groups.html
+++ b/groups.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,9 +7,6 @@
   <meta name="description" content="A group page">
   <link rel="preconnect" href="https://api.w3.org" />
   <link rel="preconnect" href="https://w3c.github.io" />
-  <!--
-    To get your own API key, go to https://www.w3.org/users/myprofile/apikeys
-  -->
   <style>
     @keyframes fadeInOpacity {
       0% {
@@ -346,10 +343,8 @@
   </main>
 
   <script type="module">
-    import { fetchGroups, setW3CKey } from './w3c.js';
+    import { fetchGroups } from './w3c.js';
     import jsonrender from './jsonrender.js';
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     fetchGroups().then(groups => {
       let elts = document.querySelectorAll("*.group-data");

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w" data-gid='114929'>
+<html lang="en-US" data-gid='114929'>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -7,9 +7,6 @@
   <meta name="description" content="A group page">
   <link rel="preconnect" href="https://api.w3.org" />
   <link rel="preconnect" href="https://w3c.github.io" />
-  <!--
-    To get your own API key, go to https://www.w3.org/users/myprofile/apikeys
-  -->
   <style>
     @keyframes fadeInOpacity {
       0% {
@@ -433,10 +430,8 @@
 
 
   <script type="module">
-    import { fetchGroup, setW3CKey } from 'https://w3c.github.io/gargantua/w3c.js';
+    import { fetchGroup } from 'https://w3c.github.io/gargantua/w3c.js';
     import jsonrender from 'https://w3c.github.io/gargantua/jsonrender.js';
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     let gid = document.documentElement.getAttribute("data-gid");
 

--- a/issueboard.html
+++ b/issueboard.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="en-US" data-gid='wg/webperf' data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US" data-gid='wg/webperf'>
 
 <head>
   <meta charset="utf-8">

--- a/issueboards.html
+++ b/issueboards.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w">
+<html lang="en-US">
 <head>
   <meta charset="utf-8">
   <title>Issue board</title>
@@ -26,10 +26,8 @@
     -  <a href="?gtype=business">business</a>
   </p>
 <script type="module">
-    import { fetchGroups, setW3CKey } from './w3c.js';
+    import { fetchGroups } from './w3c.js';
     import jsonrender from './jsonrender.js';
-
-    setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
 
     fetchGroups().then(groups => {
       let gtypeElt = document.getElementById("gtype");

--- a/repositories.html
+++ b/repositories.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" data-apiary-key="oq0abw4w2bkwcs0k0kws44sok4cg48w" data-gid="other/tag">
+<html lang="en-US" data-gid="other/tag">
     <head>
         <title>Repositories</title>
         <!-- Required meta tags -->
@@ -134,7 +134,6 @@
 
   const config = {
     gid: document.documentElement.getAttribute("data-gid"),
-    key: document.documentElement.getAttribute("data-apiary-key"),
     cache: "https://labs.w3.org/github-cache",
   };
   for (const [key, value] of (new URL(window.location)).searchParams) {

--- a/start.js
+++ b/start.js
@@ -1,7 +1,7 @@
 import 'jsdom-global/register.js';
 import jsdom from "jsdom";
 const { JSDOM } = jsdom;
-import { fetchGroup, setW3CKey } from './w3c.js';
+import { fetchGroup } from './w3c.js';
 import jsonrender, { subscribe } from './jsonrender.js';
 import fetch from 'node-fetch';
 
@@ -49,7 +49,6 @@ function renderGroup(url) {
         for (let script of scripts) script.parentNode.removeChild(script);
         resolve(dom.serialize());
       }
-      setW3CKey(document.documentElement.getAttribute("data-apiary-key"));
       subscribe("done", done);
 
       let gid = document.documentElement.getAttribute("data-gid");

--- a/w3c.js
+++ b/w3c.js
@@ -1,10 +1,10 @@
 import LazyPromise from './lazypromise.js';
-import { fetchJSON, fetchW3C, fetchHTML, setW3CKey } from "./fetch-utils.js";
+import { fetchJSON, fetchW3C, fetchHTML } from "./fetch-utils.js";
 import fetchEvents from "./w3cevents.js";
 import specConfig from "./spec-config.js";
 import mlsConfig from "./mls-config.js";
 
-// export { fetchGroup, fetchGroups, fetchJSON, setW3CKey };
+// export { fetchGroup, fetchGroups, fetchJSON };
 
 const CACHE = "https://labs.w3.org/github-cache";
 
@@ -418,4 +418,4 @@ function sortSpecifications(a, b) {
 }
 
 // export default fetchGroup;
-export { fetchGroup, fetchGroups, fetchJSON, fetchHTML, fetchW3C, setW3CKey };
+export { fetchGroup, fetchGroups, fetchJSON, fetchHTML, fetchW3C };


### PR DESCRIPTION
We no longer have to use an API key to access the W3C API.
That PR removes everything related to the API key.